### PR TITLE
as を用いている場所を除去した。

### DIFF
--- a/src/user/application/deleteUser.test.ts
+++ b/src/user/application/deleteUser.test.ts
@@ -79,7 +79,10 @@ describe("DeleteUser Use Case", () => {
   });
 
   it("should fail if user is already deleted", async () => {
-    const deletedUser = { ...mockUser, deletedAt: new Date() } as User;
+    const deletedUser = Schema.decodeSync(User)({
+      ...mockUser,
+      deletedAt: new Date(),
+    });
     const mockWriter: IUserWriter = {
       findEntityByChannelId: () => Effect.succeed(Option.some(deletedUser)),
       softDelete: () => Effect.fail(new Error("Should not be called")),


### PR DESCRIPTION
# 目的

as を使用していると型の保証がうまくいかないので、as を用いないようにした。
しかし as const や、テストユーティリティの as any: 技術的制約による意図的な使用（test-utils/schema.ts
）などでは利用している。